### PR TITLE
Genericize basic database/model functions

### DIFF
--- a/src/BookBrainz/Database.hs
+++ b/src/BookBrainz/Database.hs
@@ -6,19 +6,7 @@ This module is very low level, and deals with executing arbitrary SQL. You are
 likely more interested in the various 'BookBrainz.Model' modules. -}
 module BookBrainz.Database
        (
-         Row
-       , (!)
-       , prefixedRow
-
-         -- * Database Operations
-       , query
-       , queryOne
-
-         -- * Connection Handling
-       , HasDatabase(..)
-       , Database
-       , connectionHandle
-       , openConnection
+         openConnection
        ) where
 
 import Control.Applicative      ((<$>))
@@ -26,7 +14,7 @@ import Control.Applicative      ((<$>))
 import Control.Monad.IO.Class   (MonadIO, liftIO)
 import Database.HDBC.PostgreSQL (connectPostgreSQL)
 
-import BrainzStem.Database
+import BrainzStem.Database      (Database(..))
 
 --------------------------------------------------------------------------------
 -- | Open a connection to the BookBrainz PostgreSQL database.

--- a/src/BookBrainz/Database.hs
+++ b/src/BookBrainz/Database.hs
@@ -22,89 +22,14 @@ module BookBrainz.Database
        ) where
 
 import Control.Applicative      ((<$>))
-import Data.List                (isPrefixOf)
 
 import Control.Monad.IO.Class   (MonadIO, liftIO)
-import Data.Convertible         (Convertible)
-import Data.Map                 (Map, findWithDefault, mapKeys, filterWithKey)
-import Database.HDBC            (fetchAllRowsMap, prepare, execute, SqlValue
-                                ,fromSql, fetchRow)
-import Database.HDBC.PostgreSQL (Connection, connectPostgreSQL)
+import Database.HDBC.PostgreSQL (connectPostgreSQL)
 
--- | A row is a mapping of column names to 'SqlValue's.
-type Row = Map String SqlValue
-
---------------------------------------------------------------------------------
--- | Holds a connection to the database.
-data Database = Database
-    { {-| Extract the 'Connection' from a 'Database'. You will commonly not
-      need to call this. Most functions in this module operate on anything that
-      is an instance of the 'HasDatabase' class. -}
-      connectionHandle :: Connection
-    }
-
---------------------------------------------------------------------------------
--- | A monad that has a connection to the BookBrainz database.
-class MonadIO m => HasDatabase m where
-  -- | Get the @Connection@ to PostgreSQL.
-  askConnection :: m Connection
-
---------------------------------------------------------------------------------
-{-| Perform a SQL query on the database, and return a 'Map' for each row to
-access the values in an order-independent manner. -}
-query :: HasDatabase m
-      => String                  {-^ The raw SQL to execute. Use @?@ to
-                                     indicate placeholders. -}
-      -> [SqlValue]              {-^ Values for each placeholder according
-                                     to its position in the SQL statement. -}
-      -> m [Row]                 {-^ A 'Map' of attribute name to attribute value
-                                     for each row. Can be the empty list. -}
-query sql bind = do
-  conn <- askConnection
-  liftIO $ do
-    stmt <- prepare conn sql
-    execute stmt bind
-    fetchAllRowsMap stmt
-
---------------------------------------------------------------------------------
-{-| Perform a SQL query on the database, and return the first column of the
-first row. -}
-queryOne :: (HasDatabase m, Convertible SqlValue v, Functor m)
-         => String                  {-^ The raw SQL to execute. Use @?@ to
-                                        indicate placeholders. -}
-         -> [SqlValue]              {-^ Values for each placeholder according
-                                        to its position in the SQL statement. -}
-         -> m (Maybe v)             {-^ The column value. -}
-queryOne sql bind = do
-  conn <- askConnection
-  fmap (fromSql . head) `fmap`
-    liftIO (do stmt <- prepare conn sql
-               execute stmt bind
-               fetchRow stmt)
+import BrainzStem.Database
 
 --------------------------------------------------------------------------------
 -- | Open a connection to the BookBrainz PostgreSQL database.
 openConnection :: MonadIO m => m Database  -- ^ A connected 'Database'.
 openConnection =
   liftIO $ Database <$> connectPostgreSQL "dbname=bookbrainz user=bookbrainz"
-
---------------------------------------------------------------------------------
--- | Attempt to find the value of a column, throwing an exception if it can't
--- be found.
-(!) :: (Convertible SqlValue a)
-    => Row    -- ^ The row to look up a column value from.
-    -> String -- ^ The name of the column to find a value for.
-    -> a
-row ! k = fromSql $ findWithDefault (notFound k) k row
-  where notFound = error . (("IN " ++ show row ++ " could not find: ") ++)
-
-infixl 9 !
-
---------------------------------------------------------------------------------
--- | Finds all columns that match a prefix, and strips the prefix.
-prefixedRow :: String -- ^ The prefix to find and filter.
-            -> Row    -- ^ The row to manipulate.
-            -> Row    -- ^ The filtered and transformed row.
-prefixedRow pre r = rewriteKey `mapKeys` (hasPrefix `filterWithKey` r)
-  where hasPrefix k _ = pre `isPrefixOf` k
-        rewriteKey = drop (length pre)

--- a/src/BookBrainz/Model.hs
+++ b/src/BookBrainz/Model.hs
@@ -22,7 +22,7 @@ import Data.Copointed      (copoint)
 import Data.UUID           (UUID)
 import Database.HDBC       (SqlValue, toSql)
 
-import BookBrainz.Database (HasDatabase, query, Row, (!))
+import BrainzStem.Database (HasDatabase, query, Row, (!))
 import BookBrainz.Types    (LoadedCoreEntity(..), LoadedEntity(..), Ref(..))
 
 {-| Represents the table name for an entity. @a@ is the type of entity this

--- a/src/BookBrainz/Model/Book.hs
+++ b/src/BookBrainz/Model/Book.hs
@@ -13,7 +13,7 @@ import Database.HDBC           (toSql)
 import System.Random           (randomIO)
 
 import BrainzStem.Database     (HasDatabase, query, queryOne)
-import BookBrainz.Model        (CoreEntity(..), HasTable(..), coreEntityFromRow
+import BrainzStem.Model        (CoreEntity(..), HasTable(..), coreEntityFromRow
                                ,TableName(..), (!))
 import BookBrainz.Types
 

--- a/src/BookBrainz/Model/Book.hs
+++ b/src/BookBrainz/Model/Book.hs
@@ -12,7 +12,7 @@ import Data.UUID               (UUID)
 import Database.HDBC           (toSql)
 import System.Random           (randomIO)
 
-import BookBrainz.Database     (HasDatabase, query, queryOne)
+import BrainzStem.Database     (HasDatabase, query, queryOne)
 import BookBrainz.Model        (CoreEntity(..), HasTable(..), coreEntityFromRow
                                ,TableName(..), (!))
 import BookBrainz.Types

--- a/src/BookBrainz/Model/Country.hs
+++ b/src/BookBrainz/Model/Country.hs
@@ -1,7 +1,7 @@
 -- | Functions for working with 'BookBrainz.Types.Country.Country' entities.
 module BookBrainz.Model.Country where
 
-import BookBrainz.Model (HasTable(..), Entity(..), TableName(..), Key(..), (!))
+import BrainzStem.Model (HasTable(..), Entity(..), TableName(..), Key(..), (!))
 import BookBrainz.Types
 
 instance HasTable Country where

--- a/src/BookBrainz/Model/Edition.hs
+++ b/src/BookBrainz/Model/Edition.hs
@@ -4,7 +4,7 @@ module BookBrainz.Model.Edition
          findBookEditions
        ) where
 
-import BookBrainz.Database (HasDatabase, query)
+import BrainzStem.Database (HasDatabase, query)
 import BookBrainz.Model    (CoreEntity(..), HasTable(..), coreEntityFromRow
                            ,TableName(..), (!), rowKey)
 import BookBrainz.Types

--- a/src/BookBrainz/Model/Edition.hs
+++ b/src/BookBrainz/Model/Edition.hs
@@ -5,7 +5,7 @@ module BookBrainz.Model.Edition
        ) where
 
 import BrainzStem.Database (HasDatabase, query)
-import BookBrainz.Model    (CoreEntity(..), HasTable(..), coreEntityFromRow
+import BrainzStem.Model    (CoreEntity(..), HasTable(..), coreEntityFromRow
                            ,TableName(..), (!), rowKey)
 import BookBrainz.Types
 

--- a/src/BookBrainz/Model/EditionFormat.hs
+++ b/src/BookBrainz/Model/EditionFormat.hs
@@ -2,7 +2,7 @@
 -- entities.
 module BookBrainz.Model.EditionFormat where
 
-import BookBrainz.Model (HasTable(..), Entity(..), TableName(..), (!))
+import BrainzStem.Model (HasTable(..), Entity(..), TableName(..), (!))
 import BookBrainz.Types
 
 instance HasTable EditionFormat where

--- a/src/BookBrainz/Model/Language.hs
+++ b/src/BookBrainz/Model/Language.hs
@@ -1,7 +1,7 @@
 -- | Functions for working with 'BookBrainz.Types.Language.Language' entities.
 module BookBrainz.Model.Language where
 
-import BookBrainz.Model (HasTable(..), Entity(..), TableName(..), Key(..), (!))
+import BrainzStem.Model (HasTable(..), Entity(..), TableName(..), Key(..), (!))
 import BookBrainz.Types
 
 instance HasTable Language where

--- a/src/BookBrainz/Model/Person.hs
+++ b/src/BookBrainz/Model/Person.hs
@@ -9,7 +9,7 @@ import Database.HDBC          (toSql)
 import System.Random
 
 import BrainzStem.Database     (HasDatabase, query, (!))
-import BookBrainz.Model        (CoreEntity(..), HasTable(..), coreEntityFromRow
+import BrainzStem.Model        (CoreEntity(..), HasTable(..), coreEntityFromRow
                                ,TableName(..))
 import BookBrainz.Types
 

--- a/src/BookBrainz/Model/Person.hs
+++ b/src/BookBrainz/Model/Person.hs
@@ -8,7 +8,7 @@ import Data.UUID
 import Database.HDBC          (toSql)
 import System.Random
 
-import BookBrainz.Database
+import BrainzStem.Database     (HasDatabase, query, (!))
 import BookBrainz.Model        (CoreEntity(..), HasTable(..), coreEntityFromRow
                                ,TableName(..))
 import BookBrainz.Types

--- a/src/BookBrainz/Model/Publisher.hs
+++ b/src/BookBrainz/Model/Publisher.hs
@@ -1,7 +1,7 @@
 -- | Functions for working with 'BookBrainz.Types.Publisher.Publisher' entities.
 module BookBrainz.Model.Publisher where
 
-import BookBrainz.Model    (CoreEntity(..), HasTable(..)
+import BrainzStem.Model    (CoreEntity(..), HasTable(..)
                            ,TableName(..), (!))
 import BookBrainz.Types
 

--- a/src/BookBrainz/Model/Role.hs
+++ b/src/BookBrainz/Model/Role.hs
@@ -7,7 +7,7 @@ module BookBrainz.Model.Role
 
 import Database.HDBC           (toSql)
 
-import BookBrainz.Database     (HasDatabase, prefixedRow, query, (!))
+import BrainzStem.Database     (HasDatabase, prefixedRow, query, (!))
 import BookBrainz.Model        (Entity(..), coreEntityFromRow, HasTable(..)
                                ,TableName(..))
 import BookBrainz.Model.Person ()

--- a/src/BookBrainz/Model/Role.hs
+++ b/src/BookBrainz/Model/Role.hs
@@ -8,7 +8,7 @@ module BookBrainz.Model.Role
 import Database.HDBC           (toSql)
 
 import BrainzStem.Database     (HasDatabase, prefixedRow, query, (!))
-import BookBrainz.Model        (Entity(..), coreEntityFromRow, HasTable(..)
+import BrainzStem.Model        (Entity(..), coreEntityFromRow, HasTable(..)
                                ,TableName(..))
 import BookBrainz.Model.Person ()
 import BookBrainz.Types

--- a/src/BookBrainz/Script.hs
+++ b/src/BookBrainz/Script.hs
@@ -9,7 +9,8 @@ module BookBrainz.Script
 import Control.Monad.Reader
 import Database.HDBC.PostgreSQL (Connection)
 
-import BookBrainz.Database      (openConnection, HasDatabase (..), Database (..))
+import BrainzStem.Database      (HasDatabase(..), Database(..))	
+import BookBrainz.Database      (openConnection)
 
 -- | The state accessible to the script.
 data ScriptState = ScriptState {

--- a/src/BookBrainz/Types.hs
+++ b/src/BookBrainz/Types.hs
@@ -9,7 +9,4 @@ import BookBrainz.Types.Person       as X
 import BookBrainz.Types.Publisher    as X
 import BookBrainz.Types.Role         as X
 
--- Import for type class instances
-import BookBrainz.Types.Newtypes ()
-
 import BrainzStem.Types              as X

--- a/src/BookBrainz/Web/Handler/Book.hs
+++ b/src/BookBrainz/Web/Handler/Book.hs
@@ -18,8 +18,8 @@ import           Snap.Types
 import           Text.Digestive.Forms.Snap
 import           Text.Digestive.Blaze.Html5
 
+import           BrainzStem.Model
 import qualified BookBrainz.Forms as Forms
-import           BookBrainz.Model
 import           BookBrainz.Model.Book
 import           BookBrainz.Model.Edition
 import           BookBrainz.Model.Publisher      ()

--- a/src/BookBrainz/Web/Handler/Edition.hs
+++ b/src/BookBrainz/Web/Handler/Edition.hs
@@ -12,7 +12,7 @@ import           Data.Traversable               (traverse)
 import           Data.Copointed                 (copoint)
 import           Data.UUID
 
-import           BookBrainz.Model
+import           BrainzStem.Model
 import           BookBrainz.Model.Book          ()
 import           BookBrainz.Model.Country       ()
 import           BookBrainz.Model.Edition       ()

--- a/src/BookBrainz/Web/Handler/Person.hs
+++ b/src/BookBrainz/Web/Handler/Person.hs
@@ -7,7 +7,7 @@ module BookBrainz.Web.Handler.Person
 
 import           Data.UUID               (UUID)
 
-import           BookBrainz.Model
+import           BrainzStem.Model
 import           BookBrainz.Model.Person ()
 import           BookBrainz.Web.Handler  (output, onNothing)
 import           BookBrainz.Web.Snaplet  (BookBrainzHandler)

--- a/src/BookBrainz/Web/Handler/Publisher.hs
+++ b/src/BookBrainz/Web/Handler/Publisher.hs
@@ -7,7 +7,7 @@ module BookBrainz.Web.Handler.Publisher
 
 import           Data.UUID               (UUID)
 
-import           BookBrainz.Model
+import           BrainzStem.Model
 import           BookBrainz.Model.Publisher ()
 import           BookBrainz.Web.Handler  (output, onNothing)
 import           BookBrainz.Web.Snaplet  (BookBrainzHandler)

--- a/src/BookBrainz/Web/Snaplet.hs
+++ b/src/BookBrainz/Web/Snaplet.hs
@@ -15,7 +15,7 @@ module BookBrainz.Web.Snaplet
 import Data.Lens.Template
 import Snap.Snaplet
 
-import BookBrainz.Database (HasDatabase(..))
+import BrainzStem.Database (HasDatabase(..))
 import BookBrainz.Web.Snaplet.Database
 
 {-| The BookBrainz snaplet. See lenses below in order to access child

--- a/src/BookBrainz/Web/Snaplet/Database.hs
+++ b/src/BookBrainz/Web/Snaplet/Database.hs
@@ -15,8 +15,8 @@ import           Data.Lens.Common         (Lens)
 import qualified Database.HDBC as HDBC
 import           Snap.Snaplet
 
-import BookBrainz.Database ( Database, HasDatabase(..), connectionHandle
-                           , openConnection)
+import BrainzStem.Database (Database, HasDatabase(..), connectionHandle)
+import BookBrainz.Database (openConnection)
 
 --------------------------------------------------------------------------------
 -- | Initialize the database snaplet with a new connection.

--- a/src/BrainzStem/Database.hs
+++ b/src/BrainzStem/Database.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+{-| Connect to a MetaBrainz PostgreSQL database and interact with it.
+
+This module is very low level, and deals with executing arbitrary SQL. You are
+likely more interested in 'BrainzStem.Model'. -}
+
+module BrainzStem.Database
+       (
+         Row
+       , (!)
+       , prefixedRow
+
+         -- * Database Operations
+       , query
+       , queryOne
+
+         -- * Connection Handling
+       , HasDatabase(..)
+       , Database(Database)
+       , connectionHandle
+       ) where
+
+import Data.List                (isPrefixOf)
+
+import Control.Monad.IO.Class   (MonadIO, liftIO)
+import Data.Convertible         (Convertible)
+import Data.Map                 (Map, findWithDefault, mapKeys, filterWithKey)
+import Database.HDBC            (fetchAllRowsMap, prepare, execute, SqlValue
+                                ,fromSql, fetchRow)
+import Database.HDBC.PostgreSQL (Connection)
+
+-- | A row is a mapping of column names to 'SqlValue's.
+type Row = Map String SqlValue
+
+--------------------------------------------------------------------------------
+-- | Holds a connection to the database.
+data Database = Database
+    { {-| Extract the 'Connection' from a 'Database'. You will commonly not
+      need to call this. Most functions in this module operate on anything that
+      is an instance of the 'HasDatabase' class. -}
+      connectionHandle :: Connection
+    }
+
+--------------------------------------------------------------------------------
+-- | A monad that has a connection to a MetaBrainz database.
+class MonadIO m => HasDatabase m where
+  -- | Get the @Connection@ to PostgreSQL.
+  askConnection :: m Connection
+
+--------------------------------------------------------------------------------
+{-| Perform a SQL query on the database, and return a 'Map' for each row to
+access the values in an order-independent manner. -}
+query :: HasDatabase m
+      => String                  {-^ The raw SQL to execute. Use @?@ to
+                                     indicate placeholders. -}
+      -> [SqlValue]              {-^ Values for each placeholder according
+                                     to its position in the SQL statement. -}
+      -> m [Row]                 {-^ A 'Map' of attribute name to attribute value
+                                     for each row. Can be the empty list. -}
+query sql bind = do
+  conn <- askConnection
+  liftIO $ do
+    stmt <- prepare conn sql
+    execute stmt bind
+    fetchAllRowsMap stmt
+
+--------------------------------------------------------------------------------
+{-| Perform a SQL query on the database, and return the first column of the
+first row. -}
+queryOne :: (HasDatabase m, Convertible SqlValue v, Functor m)
+         => String                  {-^ The raw SQL to execute. Use @?@ to
+                                        indicate placeholders. -}
+         -> [SqlValue]              {-^ Values for each placeholder according
+                                        to its position in the SQL statement. -}
+         -> m (Maybe v)             {-^ The column value. -}
+queryOne sql bind = do
+  conn <- askConnection
+  fmap (fromSql . head) `fmap`
+    liftIO (do stmt <- prepare conn sql
+               execute stmt bind
+               fetchRow stmt)
+
+--------------------------------------------------------------------------------
+-- | Attempt to find the value of a column, throwing an exception if it can't
+-- be found.
+(!) :: (Convertible SqlValue a)
+    => Row    -- ^ The row to look up a column value from.
+    -> String -- ^ The name of the column to find a value for.
+    -> a
+row ! k = fromSql $ findWithDefault (notFound k) k row
+  where notFound = error . (("IN " ++ show row ++ " could not find: ") ++)
+
+infixl 9 !
+
+--------------------------------------------------------------------------------
+-- | Finds all columns that match a prefix, and strips the prefix.
+prefixedRow :: String -- ^ The prefix to find and filter.
+            -> Row    -- ^ The row to manipulate.
+            -> Row    -- ^ The filtered and transformed row.
+prefixedRow pre r = rewriteKey `mapKeys` (hasPrefix `filterWithKey` r)
+  where hasPrefix k _ = pre `isPrefixOf` k
+        rewriteKey = drop (length pre)

--- a/src/BrainzStem/Model.hs
+++ b/src/BrainzStem/Model.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-| Common functions for accessing entities. -}
-module BookBrainz.Model
-       ( -- * Entity Manpulation
+module BrainzStem.Model
+       (
+         -- * Entity Manipulation
          CoreEntity(..)
        , Entity(..)
 
@@ -10,7 +11,7 @@ module BookBrainz.Model
        , HasTable(..)
        , InDatabase(..)
 
-         -- * Low level functions and types
+         -- * Low Level Functions and Types
        , TableName(TableName)
        , Key(Key)
        , (!)
@@ -23,7 +24,7 @@ import Data.UUID           (UUID)
 import Database.HDBC       (SqlValue, toSql)
 
 import BrainzStem.Database (HasDatabase, query, Row, (!))
-import BookBrainz.Types    (LoadedCoreEntity(..), LoadedEntity(..), Ref(..))
+import BrainzStem.Types    (LoadedCoreEntity(..), LoadedEntity(..), Ref(..))
 
 {-| Represents the table name for an entity. @a@ is the type of entity this
 is a table name for. -}

--- a/src/BrainzStem/Types.hs
+++ b/src/BrainzStem/Types.hs
@@ -11,6 +11,9 @@ import Data.Copointed
 import Data.UUID
 import Database.HDBC    (SqlValue)
 
+-- Import for type class instances
+import BrainzStem.Types.Newtypes ()
+
 --------------------------------------------------------------------------------
 -- | Represents a reference in a database. @entity@ is a phantom type which
 -- tracks what type of entity this reference refers to.

--- a/src/BrainzStem/Types/Newtypes.hs
+++ b/src/BrainzStem/Types/Newtypes.hs
@@ -2,7 +2,7 @@
 
 {-| New types of atomic data and type classes for attributes used in other,
 larger sum types. -}
-module BookBrainz.Types.Newtypes () where
+module BrainzStem.Types.Newtypes () where
 
 import Data.Convertible (Convertible(..), convError)
 import Data.UUID        (UUID, fromString, toString)


### PR DESCRIPTION
Split all Model and Database (except openConnection) functions into BrainzStem for later reuse.
